### PR TITLE
Refactoring + Sorting of lines

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod file_entry;
 mod filesystem;
+mod parse_file_name_error;
 mod parser;
 mod utils;
 mod walker;

--- a/src/parse_file_name_error.rs
+++ b/src/parse_file_name_error.rs
@@ -1,0 +1,33 @@
+use colored::Colorize;
+use std::error::Error;
+use std::fmt;
+
+#[derive(Debug, Clone)]
+pub struct ParseFileNameError {
+    file_name: String,
+}
+
+impl fmt::Display for ParseFileNameError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}: '{}' doesn't match the pattern! (<TICKET_NUMBER>_<SECTION>_...)",
+            "ERROR".red(),
+            self.file_name
+        )
+    }
+}
+
+impl Error for ParseFileNameError {}
+
+impl From<String> for ParseFileNameError {
+    fn from(file_name: String) -> Self {
+        ParseFileNameError { file_name }
+    }
+}
+
+impl ParseFileNameError {
+    pub fn new(file_name: String) -> ParseFileNameError {
+        ParseFileNameError { file_name }
+    }
+}

--- a/src/parse_file_name_error.rs
+++ b/src/parse_file_name_error.rs
@@ -37,7 +37,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_ParseFileNameError_new() -> Result<(), String> {
+    fn test_new() -> Result<(), String> {
         let output = ParseFileNameError::new("my_file_name.txt".to_owned());
         let expected = ParseFileNameError {
             file_name: "my_file_name.txt".to_owned(),

--- a/src/parse_file_name_error.rs
+++ b/src/parse_file_name_error.rs
@@ -31,3 +31,19 @@ impl ParseFileNameError {
         ParseFileNameError { file_name }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ParseFileNameError_new() -> Result<(), String> {
+        let output = ParseFileNameError::new("my_file_name.txt".to_owned());
+        let expected = ParseFileNameError {
+            file_name: "my_file_name.txt".to_owned(),
+        };
+        assert_eq!(output.file_name, expected.file_name);
+
+        Ok(())
+    }
+}

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -25,7 +25,7 @@ pub fn create_version_line(version: String, date: String) -> String {
 pub fn generate_lines(hm: HashMap<String, Vec<FileEntry>>) -> Vec<String> {
     // TODO3: instead of using a Vec<FileEntry> use something more generic
     // so this method isn't depending on FileEntry
-    let lines: Vec<String> = hm
+    let mut lines: Vec<String> = hm
         .into_iter()
         .map(|(k, v)| {
             let section_name = k;
@@ -40,7 +40,10 @@ pub fn generate_lines(hm: HashMap<String, Vec<FileEntry>>) -> Vec<String> {
 
             format!("### {}\n- {}\n", section_name, lines.join("\n- "))
         })
-        .collect();
+        .collect::<Vec<String>>();
+    // Sort the lines to prevent random ordering due to the HashMap
+    // Ordering by the whole line is fine, since it always start in the format "### ACTION..."
+    lines.sort();
     lines
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,38 +1,7 @@
+use super::parse_file_name_error::ParseFileNameError;
+
 use super::file_entry::FileEntry;
-use colored::Colorize;
 use std::collections::HashMap;
-use std::error::Error;
-use std::fmt;
-
-#[derive(Debug, Clone)]
-pub struct ParseFileNameError {
-    file_name: String,
-}
-
-impl fmt::Display for ParseFileNameError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{}: '{}' doesn't match the pattern! (<TICKET_NUMBER>_<SECTION>_...)",
-            "ERROR".red(),
-            self.file_name
-        )
-    }
-}
-
-impl Error for ParseFileNameError {}
-
-impl From<String> for ParseFileNameError {
-    fn from(file_name: String) -> Self {
-        ParseFileNameError { file_name }
-    }
-}
-
-impl ParseFileNameError {
-    fn new(file_name: String) -> ParseFileNameError {
-        ParseFileNameError { file_name }
-    }
-}
 
 pub fn parse_file_name(name: String) -> Result<(String, String), ParseFileNameError> {
     let splitted: Vec<&str> = name.split('_').collect();


### PR DESCRIPTION
- Moved `ParseFileNameError` to a dedicated file -> `src/parse_file_name_error.rs`
- Sort generated lines (`generate_lines()`) to prevent random results